### PR TITLE
修改英文Readmez中跳转回中文readme失效的问题

### DIFF
--- a/readme-en.md
+++ b/readme-en.md
@@ -1,7 +1,7 @@
 dotnetClub.net
 ----------------------
 
-**Welcome to the dotnetClub.net project. [点此查看中文说明](https://github.com/jijiechen/dotnetclub/blob/dev/readme.md)。**
+**Welcome to the dotnetClub.net project. [点此查看中文说明](https://github.com/jijiechen/dotnetclub/blob/dev/Readme.md)。**
 
 This project is source code for a discussion website, it demonstrates how ASP.NET Core can be used to make a user generated web application. The online instance of this project is hosted at [dotnetclub.net](http://dotnetclub.net) which is exactly a real community for discussing .NET Core technical topics.
 


### PR DESCRIPTION
修改英文Readmez中跳转回中文readme失效的问题， 原因是Url中reamde若非全字匹配会找不到对应文件